### PR TITLE
The correct value for :via is :all

### DIFF
--- a/text/06_routing.markdown
+++ b/text/06_routing.markdown
@@ -76,10 +76,10 @@ method. (RuntimeError)
 @@@
 
 If you truly need to route a request that comes in via any HTTP verb, modify
-the `match` route to specify `:via => :any`
+the `match` route to specify `:via => :all`
 
 @@@ ruby
 Widgets::Application.routes.draw do
-  match "/something" => "something#index", :via => :any
+  match "/something" => "something#index", :via => :all
 end
 @@@


### PR DESCRIPTION
Page 20 says that “If you truly need to route a request that comes in via any HTTP verb, modify the `match` route to specify `:via => :any`”. That should be `:all`, not `:any`.

See https://github.com/rails/rails/blob/v4.0.4/actionpack/lib/action_dispatch/routing/mapper.rb#L183

Closes #6.
