### PR TITLE
Upgrade for ruby 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'kitabu', :git => 'https://github.com/alindeman/kitabu.git'
+gem 'kitabu'
 gem 'rubyzip', '~>0.9.9' # https://github.com/alindeman/upgradingtorails4/issues/5
 
 gem 'pygments.rb'
+gem 'yajl-ruby', '>= 1.3.0'
 gem 'redcarpet'
 
 gem 'guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,15 @@
-GIT
-  remote: https://github.com/alindeman/kitabu.git
-  revision: f500a076602fc05233d65132fa2869d1b54f1437
-  specs:
-    kitabu (1.0.0)
-      RedCloth
-      activesupport
-      coderay
-      eeepub-with-cover-support
-      i18n
-      listen
-      nokogiri
-      notifier
-      rdiscount
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
-    RedCloth (4.2.9)
-    activesupport (4.0.0)
-      i18n (~> 0.6, >= 0.6.4)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
-    atomic (1.1.14)
-    builder (3.2.2)
+    RedCloth (4.3.2)
+    activesupport (5.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    builder (3.2.3)
     coderay (1.0.8)
+    concurrent-ruby (1.0.5)
     doc_raptor (0.3.2)
       httparty (>= 0.7.0)
     eeepub-with-cover-support (0.8.8)
@@ -43,37 +26,47 @@ GEM
     httparty (0.9.0)
       multi_json (~> 1.0)
       multi_xml
-    i18n (0.6.5)
+    i18n (0.9.1)
+      concurrent-ruby (~> 1.0)
+    kitabu (1.0.5)
+      RedCloth
+      activesupport
+      coderay
+      eeepub-with-cover-support
+      i18n
+      nokogiri
+      notifier
+      rdiscount
+      rubyzip (< 1.0.0)
+      thor
     listen (0.5.3)
     lumberjack (1.0.2)
     method_source (0.8.1)
-    mini_portile (0.5.1)
-    minitest (4.7.5)
+    mini_portile2 (2.3.0)
+    minitest (5.10.3)
     multi_json (1.3.7)
     multi_xml (0.5.1)
-    nokogiri (1.6.0)
-      mini_portile (~> 0.5.0)
-    notifier (0.4.1)
-    posix-spawn (0.3.6)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    notifier (0.5.2)
     pry (0.9.10)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.3.1)
-    pygments.rb (0.3.2)
-      posix-spawn (~> 0.3.6)
-      yajl-ruby (~> 1.1.0)
+    pygments.rb (1.2.1)
+      multi_json (>= 1.0.0)
     rb-fsevent (0.9.2)
     rb-inotify (0.8.8)
       ffi (>= 0.5.0)
-    rdiscount (2.1.7)
+    rdiscount (2.2.0.1)
     redcarpet (2.1.1)
     rubyzip (0.9.9)
     slop (3.3.3)
     thor (0.16.0)
-    thread_safe (0.1.3)
-      atomic
-    tzinfo (0.3.38)
-    yajl-ruby (1.1.0)
+    thread_safe (0.3.6)
+    tzinfo (1.2.4)
+      thread_safe (~> 0.1)
+    yajl-ruby (1.3.1)
 
 PLATFORMS
   ruby
@@ -82,9 +75,13 @@ DEPENDENCIES
   doc_raptor
   guard
   guard-shell
-  kitabu!
+  kitabu
   pygments.rb
   rb-fsevent
   rb-inotify
   redcarpet
   rubyzip (~> 0.9.9)
+  yajl-ruby (>= 1.3.0)
+
+BUNDLED WITH
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Where should you go from here?
 
 ```bash
 $ bundle install
-$ bundle exec kitabu export
+$ bundle exec kitabu check
+$ bundle exec kitabu export --only html
 $ ls output/
 ```
 


### PR DESCRIPTION
The build instructions didn't work for me on Ruby 2.4.

`bundle install` failed with this, for example:
```
yajl_ext.c:852:22: error: ‘rb_cFixnum’ undeclared (first use in this function)
     rb_define_method(rb_cFixnum, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
                      ^~~~~~~~~~
```

This upgrades some gems so that one can actually build it on a recent Ruby :)